### PR TITLE
Fix(useDraftManager): Maintain hasDraft state on load

### DIFF
--- a/src/hooks/__tests__/useDraftManager.test.ts
+++ b/src/hooks/__tests__/useDraftManager.test.ts
@@ -1,0 +1,62 @@
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useDraftManager } from '../useDraftManager';
+import type { EvaluationResult, UploadedFile } from '../../types';
+
+// Mock data for testing
+const mockResults: EvaluationResult = {
+  totalScore: 85,
+  maxScore: 100,
+  grades: { '1': { score: 10, maxScore: 10, comments: 'Good job' } },
+  feedback: 'Well done',
+};
+const mockEvaluationId = 'eval-123';
+const mockStudentInfo = {
+  name: 'John Doe',
+  id: 'student-456',
+  subject: 'Math',
+  examType: 'Final',
+};
+const mockStudentPaperFiles: UploadedFile[] = [
+  { id: 'file-1', file: new File(['content'], 'paper.pdf', { type: 'application/pdf' }) },
+];
+
+const DRAFT_KEY = 'evaluation_draft';
+
+describe('useDraftManager', () => {
+  // Clear localStorage before each test
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('should not change hasDraft to false after loading a draft', () => {
+    const { result } = renderHook(() => useDraftManager());
+
+    // 1. Save a draft
+    act(() => {
+      result.current.saveDraft(
+        mockResults,
+        mockEvaluationId,
+        mockStudentInfo,
+        mockStudentPaperFiles
+      );
+    });
+
+    // Verify draft is saved and hasDraft is true
+    expect(result.current.hasDraft).toBe(true);
+    expect(localStorage.getItem(DRAFT_KEY)).not.toBeNull();
+
+    // 2. Load the draft
+    let loadedDraft;
+    act(() => {
+      loadedDraft = result.current.loadDraft();
+    });
+
+    // Verify draft data is loaded correctly
+    expect(loadedDraft).not.toBeNull();
+    expect(loadedDraft?.evaluationId).toBe(mockEvaluationId);
+
+    // 3. Assert that hasDraft is still true (This is where it should fail)
+    expect(result.current.hasDraft).toBe(true);
+  });
+});

--- a/src/hooks/useDraftManager.ts
+++ b/src/hooks/useDraftManager.ts
@@ -70,7 +70,6 @@ export function useDraftManager() {
     
     try {
       const draftData = JSON.parse(draft);
-      setHasDraft(false);
       return draftData;
     } catch (error) {
       console.error('Failed to load draft:', error);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest" />
 import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 
@@ -52,6 +53,10 @@ export default defineConfig(({ mode }) => {
   
   return {
     plugins: [react()],
+    test: {
+      globals: true,
+      environment: 'jsdom',
+    },
     server: {
       host: true,
       port: parseInt(env.VITE_DEV_PORT || String(DEFAULT_DEV_PORT)),


### PR DESCRIPTION
The `loadDraft` function in the `useDraftManager` hook was incorrectly setting the `hasDraft` state to `false` immediately after a draft was loaded. This would cause UI elements that depend on this state (e.g., a "Load Draft" button) to disappear prematurely, even though the draft still exists in localStorage.

This commit removes the erroneous state update, ensuring that the `hasDraft` state accurately reflects the presence of a draft in storage until it is explicitly cleared.

A new test case has been added to verify this fix. The Vitest configuration was also updated to use the 'jsdom' environment to support testing with localStorage.